### PR TITLE
Fix font when using polish language

### DIFF
--- a/qlinstaller/resources/polish_font_read
+++ b/qlinstaller/resources/polish_font_read
@@ -1,0 +1,1 @@
+Clone russian.ttf as polish.ttf to fix font when using polish language.


### PR DESCRIPTION
Clone russian.ttf as polish.ttf to fix font when using polish language.